### PR TITLE
Refs [TASK][35604] Handle event Setting Screen

### DIFF
--- a/app/src/main/java/com/example/itbook/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/example/itbook/ui/settings/SettingsFragment.kt
@@ -1,17 +1,52 @@
 package com.example.itbook.ui.settings
 
+import android.widget.CompoundButton
 import com.example.itbook.R
 import com.example.itbook.base.BaseFragment
+import com.example.itbook.utils.MySharedPreferences
+import com.example.itbook.utils.restart
+import com.example.itbook.utils.setLanguage
+import kotlinx.android.synthetic.main.fragment_settings.*
 
 class SettingsFragment : BaseFragment() {
     override val layoutResource = R.layout.fragment_settings
+
+    private var preferences: MySharedPreferences? = null
+    private var enableSwitchChange = true
 
     override fun initViews() {
     }
 
     override fun initData() {
+        preferences = context?.let { MySharedPreferences.getInstance(it) }
+        preferences?.getString(STRING_LANGUAGE, resources.getString(R.string.text_language_en))
+            ?.let { setSwitch(it) }
     }
 
     override fun initListeners() {
+        switchLanguage.setOnCheckedChangeListener(onCheckedChangeListener)
+    }
+
+    private fun setSwitch(language: String) {
+        enableSwitchChange = false
+        switchLanguage.isChecked = language != resources.getString(R.string.text_language_en)
+        enableSwitchChange = true
+    }
+
+    private val onCheckedChangeListener = CompoundButton.OnCheckedChangeListener { _, isChecked ->
+        var language = resources.getString(R.string.text_language_en)
+
+        if (enableSwitchChange) {
+            activity?.apply {
+                if (isChecked) language = resources.getString(R.string.text_language_vi)
+                setLanguage(language)
+                context?.let { preferences?.writeString(STRING_LANGUAGE, language) }
+                restart()
+            }
+        }
+    }
+
+    companion object {
+        const val STRING_LANGUAGE = "language"
     }
 }

--- a/app/src/main/java/com/example/itbook/utils/ActivityExtension.kt
+++ b/app/src/main/java/com/example/itbook/utils/ActivityExtension.kt
@@ -1,0 +1,22 @@
+@file:Suppress("DEPRECATION")
+
+package com.example.itbook.utils
+
+import android.app.Activity
+import android.content.Intent
+import android.content.res.Configuration
+import com.example.itbook.ui.main.MainActivity
+import java.util.*
+
+fun Activity.setLanguage(locale: String) {
+    val locale = Locale(locale)
+    val configuration = Configuration()
+    configuration.locale = locale
+    baseContext.resources.updateConfiguration(configuration, baseContext.resources.displayMetrics)
+}
+
+fun Activity.restart() {
+    val intent = Intent(this, MainActivity::class.java)
+    startActivity(intent)
+    finish()
+}

--- a/app/src/main/java/com/example/itbook/utils/MySharedPreferences.kt
+++ b/app/src/main/java/com/example/itbook/utils/MySharedPreferences.kt
@@ -1,0 +1,26 @@
+package com.example.itbook.utils
+
+import android.content.Context
+import android.content.Context.MODE_PRIVATE
+
+class MySharedPreferences private constructor(context: Context) {
+    private val preferences = context.getSharedPreferences(SHARED_PREFERENCES_NAME, MODE_PRIVATE)
+    private val editor = preferences.edit()
+
+    fun writeString(key: String, value: String) {
+        editor.apply {
+            putString(key, value)
+            commit()
+        }
+    }
+
+    fun getString(key: String, defaultString: String) = preferences.getString(key, defaultString)
+
+    companion object {
+        const val SHARED_PREFERENCES_NAME = "it"
+        private var instance: MySharedPreferences? = null
+
+        fun getInstance(context: Context) =
+            instance ?: MySharedPreferences(context).also { instance = it }
+    }
+}


### PR DESCRIPTION
## Related Tickets
- [#Task 35604: Handle event Setting Screen](https://edu-redmine.sun-asterisk.vn/issues/35604)
## WHAT
- 
## Evidence (Screenshot or Video)

## Review Checklist

Category | View Point | Description | Self review | Reviewer2 (name)
--- | --- | --- | --- | ---
Conventions | Sun* coding conventions | https://github.com/framgia/coding-standards/tree/master/eng/android |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Conventions | Kotlin coding conventions | https://kotlinlang.org/docs/coding-conventions.html |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Redmine | Sun* Redmine working process  | https://github.com/framgia/Training-Guideline/blob/master/WorkingProcess/redmine/redmine.md |<li>- [ ] yes</li>|<li>- [ ] yes</li>  

## Notes (Optional)
*(Impacted Areas in Application(List features, api, models or services that this PR will affect))*

*(List gem, library third party add new)*

*(Other notes)*
